### PR TITLE
Add babel-plugin-dynamic-import-node suggestion to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ plugin to your Babel config:
 - `server` (default: `true`) - When `true` adds `serverSideRequirePath` config.
 - `webpack` (default: `false`) - When `true` adds `webpackRequireWeakId` config.
 
+**Note:**
+
+If you're using babel + webpack with [syntax-dynamic-import](https://babeljs.io/docs/plugins/syntax-dynamic-import/) plugin and it causes your server-side-rendering dont render on the first request. Consider using [babel-plugin-dynamic-import-node](https://github.com/airbnb/babel-plugin-dynamic-import-node) plugin for your server build. It'll convert **import()** to **require()** and ensure synchronous rendering.  
+
 ## FAQ
 
 #### Why are there multiple options for specifying a component?


### PR DESCRIPTION
Hello, firstly thanks for making this library and sorry for my english. I had an issue and found a solution but I'm not sure about it. Here is my story;

After using react-loadable with babel-plugin i'm encounter an issue which causes my first renders on server wont serves loadable component. After some digging i realise webpack splits my code into two chunks (one for main and one for loadable) and tries to load loadable component with promise (with load() function in library). And because server dont waits for this loading completed; my first requests always returns null for loadable-component and others work well.

I dont know if this issue is common or just because of my webpack configuration, or because im using babel "[syntax-dynamic-import](https://babeljs.io/docs/plugins/syntax-dynamic-import/)" plugin (etc), but after digging for hours i found solution as using [babel-plugin-dynamic-import-node](https://github.com/airbnb/babel-plugin-dynamic-import-node) plugin for only my server side webpack (babel actually).

Since issues are disabled i had to open this PR, its okay if you dont accept it. 
